### PR TITLE
OptionWrapper's z-index adjust higher than timeline

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@channel.io/snippet",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@channel.io/snippet",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "channel.io snippet components",
   "main": "build/cjs.js",
   "module": "build/esm.js",

--- a/src/components/Dropdown/Dropdown.styled.ts
+++ b/src/components/Dropdown/Dropdown.styled.ts
@@ -59,7 +59,7 @@ export const OptionWrapper = styled.div<OptionWrapperProps>`
   background-color: ${Colors.White};
   padding: 8px 0;
   position: absolute;
-  z-index: 1;
+  z-index: 10;
   max-height: 345px;
   overflow-y: auto;
   border-radius: 8px;


### PR DESCRIPTION
V0.2.1 will be unpublished because that was published without build.

## Previous
![image](https://user-images.githubusercontent.com/33291896/105694177-f7d04080-5f43-11eb-9ef3-471a21e64b9f.png)

## Changed
![image](https://user-images.githubusercontent.com/33291896/105694183-facb3100-5f43-11eb-8572-2e8f8409afb1.png)